### PR TITLE
[Maintenance] Lock Sylius version to 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
-        "sylius/sylius": "^2.0",
+        "sylius/sylius": "~2.0.0",
         "symfony/debug-bundle": "*",
         "symfony/dotenv": "*",
         "symfony/flex": "*",


### PR DESCRIPTION
The main idea is to have each tag of `TestApplication` correspond to a specific minor version of `Sylius/Sylius` since the needed configuration can change between those.
As a user of the test app, I should only care about different versions of Sylius and leave resolving the proper version of the test app to composer.