### PR TITLE
Always create package.json based on the default file when merging

### DIFF
--- a/package.json.dist
+++ b/package.json.dist
@@ -1,0 +1,21 @@
+{
+    "license": "MIT",
+    "scripts": {
+        "preinstall": "node scripts/merge-plugin-dependencies.js",
+        "build": "encore dev",
+        "build:prod": "encore production",
+        "watch": "encore dev --watch"
+    },
+    "dependencies": {
+        "@sylius-ui/admin": "file:../sylius/src/Sylius/Bundle/AdminBundle",
+        "@sylius-ui/shop": "file:../sylius/src/Sylius/Bundle/ShopBundle",
+        "@symfony/ux-autocomplete": "file:../../../vendor/symfony/ux-autocomplete/assets",
+        "@symfony/ux-live-component": "file:../../../vendor/symfony/ux-live-component/assets"
+    },
+    "devDependencies": {
+        "@hotwired/stimulus": "^3.0.0",
+        "@symfony/stimulus-bridge": "^3.2.0",
+        "@symfony/webpack-encore": "^5.0.1",
+        "tom-select": "^2.2.2"
+    }
+}

--- a/scripts/merge-plugin-dependencies.js
+++ b/scripts/merge-plugin-dependencies.js
@@ -2,16 +2,18 @@ const fs = require('fs');
 const path = require('path');
 
 const root = path.resolve(__dirname, '..');
+const packageDistPath = path.join(root, 'package.json.dist');
 const packagePath = path.join(root, 'package.json');
 const pluginRoot = path.resolve(root, '../../..');
 const pluginPackagePath = path.join(pluginRoot, 'tests', 'TestApplication', 'package.json');
 
-if (!fs.existsSync(pluginPackagePath)) {
-    process.exit(0);
-}
+const pluginPackageExists = fs.existsSync(pluginPackagePath);
+const pluginPackage = pluginPackageExists
+    ? JSON.parse(fs.readFileSync(pluginPackagePath, 'utf-8'))
+    : { dependencies: {}, devDependencies: {} }
+;
 
-const pluginPackage = JSON.parse(fs.readFileSync(pluginPackagePath, 'utf-8'));
-const rootPackage = JSON.parse(fs.readFileSync(packagePath, 'utf-8'));
+const basePackage = JSON.parse(fs.readFileSync(packageDistPath, 'utf-8'));
 
 function mergeDependencies(target = {}, source = {}) {
     const result = { ...target };
@@ -22,7 +24,10 @@ function mergeDependencies(target = {}, source = {}) {
     return result;
 }
 
-rootPackage.dependencies = mergeDependencies(rootPackage.dependencies, pluginPackage.dependencies);
-rootPackage.devDependencies = mergeDependencies(rootPackage.devDependencies, pluginPackage.devDependencies);
+const finalPackage = {
+    ...basePackage,
+    dependencies: mergeDependencies(basePackage.dependencies, pluginPackage.dependencies),
+    devDependencies: mergeDependencies(basePackage.devDependencies, pluginPackage.devDependencies),
+};
 
-fs.writeFileSync(packagePath, JSON.stringify(rootPackage, null, 4));
+fs.writeFileSync(packagePath, JSON.stringify(finalPackage, null, 4));


### PR DESCRIPTION
This will solve the problem of managing dependencies and, for example, removing them after they have previously been added in the plugin.