### PR TITLE
Empty var directory has been added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@
 
 ###> dependencies ###
 /vendor/
-/var/
 ###< dependencies ###
 
 ###> symfony/framework-bundle ###


### PR DESCRIPTION
Added an empty var directory. Useful when files are placed in the directory. E.g. via some Behat contexts.